### PR TITLE
Ensure attributes aren't unknown after apply

### DIFF
--- a/docs/resources/manifest.md
+++ b/docs/resources/manifest.md
@@ -56,7 +56,7 @@ resource "slack-app_manifest" "example" {
 
 - `credentials` (Attributes) (see [below for nested schema](#nestedatt--credentials))
 - `id` (String) The ID of the app.
-- `oauth_authorize_url` (String) Full URL for athorization.
+- `oauth_authorize_url` (String) Full URL for authorization.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`

--- a/internal/provider/manifest_resource.go
+++ b/internal/provider/manifest_resource.go
@@ -88,7 +88,7 @@ func (r *manifestResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"oauth_authorize_url": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Full URL for athorization.",
+				MarkdownDescription: "Full URL for authorization.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -119,8 +119,8 @@ type manifestResourceModel struct {
 	OAuthAuthorizeUrl types.String `tfsdk:"oauth_authorize_url"`
 }
 
-type createManifestReqest struct {
-	AppID    string `json:"app_id,omit_empty"`
+type createManifestRequest struct {
+	AppID    string `json:"app_id,omitempty"`
 	Manifest string `json:"manifest"`
 }
 
@@ -147,7 +147,7 @@ func (r *manifestResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	request, _ := json.Marshal(createManifestReqest{
+	request, _ := json.Marshal(createManifestRequest{
 		Manifest: plan.Manifest.ValueString(),
 	})
 	var resultJson createManifestResponse
@@ -178,7 +178,7 @@ func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	request, _ := json.Marshal(createManifestReqest{
+	request, _ := json.Marshal(createManifestRequest{
 		AppID: state.ID.ValueString(),
 	})
 	var resultJson exportManifestResponse
@@ -205,7 +205,7 @@ func (r *manifestResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	request, _ := json.Marshal(createManifestReqest{
+	request, _ := json.Marshal(createManifestRequest{
 		AppID:    plan.ID.ValueString(),
 		Manifest: plan.Manifest.ValueString(),
 	})
@@ -229,7 +229,7 @@ func (r *manifestResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	request, _ := json.Marshal(createManifestReqest{
+	request, _ := json.Marshal(createManifestRequest{
 		AppID: state.ID.ValueString(),
 	})
 	err := r.client.Request(ctx, "apps.manifest.delete", request, nil)

--- a/internal/provider/manifest_resource.go
+++ b/internal/provider/manifest_resource.go
@@ -215,6 +215,15 @@ func (r *manifestResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	// Slack only returns `credentials` and `oauth_authorize_url` on create, not update. If this was an imported
+	// app, just mark these value as null to avoid "Error: Provider returned invalid result object after apply".
+	if plan.Credentials.IsUnknown() {
+		plan.Credentials = types.ObjectNull(plan.Credentials.AttributeTypes(ctx))
+	}
+	if plan.OAuthAuthorizeUrl.IsUnknown() {
+		plan.OAuthAuthorizeUrl = types.StringNull()
+	}
+
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }


### PR DESCRIPTION
For Slack apps that were imported using `terraform import`, we can never know the value of `credentials` or `oauth_authorize_url`, due to these being one-time attributes only returned on the Slack API 'apps.manifest.create' call, and not 'apps.manifest.export' or 'apps.manifest.update'.

```
╷
│ Error: Provider returned invalid result object after apply
│
│ After the apply operation, the provider still indicated an unknown value for slack-app_manifest.myapp.credentials. All values must be known after apply, so this is always a bug in the provider and should be reported in the provider's own repository. Terraform will still save the other known object values in the
│ state.
╵
╷
│ Error: Provider returned invalid result object after apply
│
│ After the apply operation, the provider still indicated an unknown value for slack-app_manifest.myapp.oauth_authorize_url. All values must be known after apply, so this is always a bug in the provider and should be reported in the provider's own repository. Terraform will still save the other known object values in
│ the state.
╵
```